### PR TITLE
Update .gitignore to ignore certificates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,11 @@
 .idea/
 go_build_testApp_go
 *.log
+
+# Prevent certificates from getting checked in
+*.ca
+*.cer
+*.crt
+*.csr
+*.key
+*.pem


### PR DESCRIPTION
Update .gitignore to ignore certificates to help prevent check in of sensitive files in the future.